### PR TITLE
fix: Add .js to the end of the .esm file name

### DIFF
--- a/packages/llm.ts/package.json
+++ b/packages/llm.ts/package.json
@@ -2,7 +2,7 @@
   "name": "llm.ts",
   "version": "0.0.6",
   "main": "dist/index.cjs",
-  "module": "dist/index.esm",
+  "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "author": "Matt Rickard <npm@matt-rickard.com>",
   "license": "MIT",

--- a/packages/llm.ts/rollup.config.js
+++ b/packages/llm.ts/rollup.config.js
@@ -23,7 +23,7 @@ export default [
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.esm",
+      file: "dist/index.esm.js",
       format: "esm",
     },
     plugins: [


### PR DESCRIPTION
Hi! This is a very cool project. I noticed that, running this in Deno fails currently because the ESM build lacks a `.js` extension - the file is `index.esm`. This PR adds a .js at the end - `index.esm.js`. This should have no effect for Node-users but make this package compatible with Deno.